### PR TITLE
Use the Bison parser actions to get the prompt.

### DIFF
--- a/shellparser.c
+++ b/shellparser.c
@@ -129,7 +129,7 @@ int printNode(Node *np) {
     return ret;
   }
 }
-
+/*
 int main() {
   char line[MAX_LENGTH+1];
   int err = 0;
@@ -144,4 +144,4 @@ int main() {
   }
   return err;
 }
-
+*/

--- a/shparser.y
+++ b/shparser.y
@@ -30,9 +30,11 @@ int yylex(void);
 start : line				{fprintf(stdout, "start\n");}
 
 line : line command '\n'                {fprintf(stdout, "line command\nWalking the tree...\n"); 
-     					 printNode($2); freeNode($2); fprintf(stdout, "\n"); YYACCEPT;}
+     					 printNode($2); freeNode($2);
+					 fprintf(stdout, "\nHEY: ");}
      | line commands '\n'               {fprintf(stdout, "line commands\nWalking the tree...\n"); 
-					 printNode($2); freeNode($2); fprintf(stdout, "\n"); YYACCEPT;}
+					 printNode($2); freeNode($2);
+					 fprintf(stdout, "\nHEY: ");}
      | /*EMPTY*/
      | line '\n'
      ;
@@ -59,11 +61,12 @@ void yyerror(const char *msg) {
 	exit(1);
 }
 
-/*
+
 int main(void) {
+  fprintf(stdout, "HEY: ");
   yyparse();
   return 0;
-}*/
+}
 /*
 int main() {
   char line[MAX_LENGTH+1];
@@ -78,5 +81,5 @@ int main() {
     }
   }
   return err;
-}*/
-
+}
+*/


### PR DESCRIPTION
Instead of putting input into a buffer, make the bison parser
actions produce a prompt. This way we don't have to worry about
input length.