### PR TITLE
Redirection and start conditions for quotes.

### DIFF
--- a/shellparser.c
+++ b/shellparser.c
@@ -251,7 +251,7 @@ int evalRedir(Node *np) {
         }
         // Do append
       } else if (np->type.RedirNode.append == 1) {
-        if((outfd = open(np->type.RedirNode.outfile, O_APPEND|O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH)) == -1) {
+        if((outfd = open(np->type.RedirNode.outfile, O_WRONLY|O_CREAT|O_APPEND, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH)) == -1) {
           fprintf(stderr, "Can't open file: %s\n", np->type.RedirNode.outfile);
           ret = -1;
         }

--- a/shellparser.c
+++ b/shellparser.c
@@ -486,6 +486,10 @@ void initialize(void) {
   b[0]="HOME";
   b[1]= getenv("HOME"); // TODO: Change this if needed
   x_setenv(2, b);
+  
+  // Global flags
+  runBG = 0;
+  doneParsing = 0;
 }
 
 int getCommand(){
@@ -511,6 +515,10 @@ int main(void) {
       case OK:
         if(runBG == 1) {
           fprintf(stderr, "Run this in BG!\n");
+        }
+        if(doneParsing ==1) {
+          fprintf(stderr, "So long!\n");
+          exit(0);
         }
         evalNode(RootNode); 
         freeNode(RootNode);

--- a/shellparser.h
+++ b/shellparser.h
@@ -34,6 +34,7 @@ typedef struct Node{
 
 Node *RootNode;
 int runBG;
+int doneParsing;
 
 Node *new_command(char* command, Node *childparams);
 Node *new_pipe(Node *command, Node *pipe);

--- a/shellparser.h
+++ b/shellparser.h
@@ -15,11 +15,17 @@
 #define ERRORS 1
 
 typedef struct Node{
-  enum { command_node, pipe_node, param_node, params_node } label;
+  enum { command_node, pipe_node, redir_node, param_node, params_node } label;
   union { struct { char*     command;
                    struct Node*     childparams; }  CommandNode;
           struct { struct Node*     command;
                    struct Node*     pipe; }         PipeNode;
+		    struct { char * infile;
+              char* outfile;
+              int append;
+              char* stderrfile;
+              int stderr_to_out;
+			        struct Node* commandline; }   RedirNode;
           struct { char*     param; }        ParamNode;
           struct { struct Node*     first;
                    struct Node*     second; }       ParamsNode;
@@ -27,11 +33,13 @@ typedef struct Node{
 } Node;
 
 Node *RootNode;
+int runBG;
 
 Node *new_command(char* command, Node *childparams);
 Node *new_pipe(Node *command, Node *pipe);
 Node *new_param(char *param);
 Node *new_params(Node *first, Node *second);
+Node *new_redir(Node *commandline, char* infile, char* outfile, int append, char* stderrfile, int stderr_to_out);
 
 void freeNode(Node *np);
 

--- a/shparser.l
+++ b/shparser.l
@@ -20,6 +20,7 @@ char * unquote(char *string);
 (&1)                                     {return STDOUT;}
 [|><\n]                 		             {return *yytext;}
 [ \t\r]+                		             {;}
+<<EOF>>                           {return END_OF_FILE;}
 
 .                       		             {yyerror("Invalid character!");}
 

--- a/shparser.l
+++ b/shparser.l
@@ -12,13 +12,16 @@ char * unquote(char *string);
 ([^\t \n\"\?\\\'\&><\|]|\\&|\\\"|\\>|\\<|\\\'|\\\|)+ {yylval.s = strdup(yytext); return WORD;}
 (\"(\\.|[^\\"])*\")|(\'(\\.|[^\\'])*\')  {char unquoted[yyleng+1];
                                           strncpy(unquoted, yytext, yyleng+1); 
-					  unquote(unquoted);
-					  yylval.s = strdup(unquoted);
-					  return WORD;}
-[|><\n]                 		 {return *yytext;}
-[ \t\r]+                		 {;}
+                                          unquote(unquoted);
+                                          yylval.s = strdup(unquoted);
+                                          return WORD;}
+(&)                                      {return *yytext;}
+(2>)					                           {return RE_STDERR;}
+(&1)                                     {return STDOUT;}
+[|><\n]                 		             {return *yytext;}
+[ \t\r]+                		             {;}
 
-.                       		 {yyerror("Invalid character!");}
+.                       		             {yyerror("Invalid character!");}
 
 %%
 

--- a/shparser.l
+++ b/shparser.l
@@ -4,32 +4,33 @@
 #include "shellparser.h"
 #include "y.tab.h"
 
+#define MAX_STR_SIZE 200
+
 char * unquote(char *string);
 %}
 
 %x DBLQUOTES SNGLQUOTES
 
 %%
+                                      char string_buf[MAX_STR_SIZE];
+                                      char *string_buf_ptr;
 
-\"  { BEGIN(DBLQUOTES);}
-
-<DBLQUOTES>\"           {BEGIN(INITIAL);}
-<DBLQUOTES>[^\"]+      {yylval.s = strdup(yytext); return WORD;
-                                      BEGIN(INITIAL);}
-
-\'  { BEGIN(SNGLQUOTES);}
-
-<SNGLQUOTES>\'           {BEGIN(INITIAL);}
-<SNGLQUOTES>[^\']+      {yylval.s = strdup(yytext); return WORD;
-                                      BEGIN(INITIAL);}
-
+\"                                      {string_buf_ptr = string_buf; BEGIN(DBLQUOTES);}
+<DBLQUOTES>[^\\"\n]*      { char *yptr = yytext;
+                                          while ( *yptr )
+                                            *string_buf_ptr++ = *yptr++; }
+<DBLQUOTES>\\n             { *string_buf_ptr++ = '\n'; }
+<DBLQUOTES>\\t              { *string_buf_ptr++ = '\t'; }
+<DBLQUOTES>\\[\\"]          { *string_buf_ptr++ = yytext[1];}
+<DBLQUOTES>\"               { yylval.s = strdup(string_buf); BEGIN(INITIAL); 
+                                           *string_buf_ptr = '\0'; return WORD;}
 
 ([^\t \n\"\?\\\'\&><\|]|\\&|\\\"|\\>|\\<|\\\'|\\\|)+ {yylval.s = strdup(yytext); return WORD;}
-(&)                                      {return *yytext;}
-(2>)					                           {return RE_STDERR;}
-(&1)                                     {return STDOUT;}
-[|><\n]                 		             {return *yytext;}
-[ \t\r]+                		             {;}
+\&                                       {return *yytext;}
+2>					                            {return RE_STDERR;}
+\&1                                     {return STDOUT;}
+[|><\n]                 		            {return *yytext;}
+[ \t\r]+                		              {;}
 <<EOF>>                           {return END_OF_FILE;}
 
 .                       		             {yyerror("Invalid character!"); return ERRTOK;}

--- a/shparser.l
+++ b/shparser.l
@@ -7,14 +7,24 @@
 char * unquote(char *string);
 %}
 
+%x DBLQUOTES SNGLQUOTES
+
 %%
 
+\"  { BEGIN(DBLQUOTES);}
+
+<DBLQUOTES>\"           {BEGIN(INITIAL);}
+<DBLQUOTES>[^\"]+      {yylval.s = strdup(yytext); return WORD;
+                                      BEGIN(INITIAL);}
+
+\'  { BEGIN(SNGLQUOTES);}
+
+<SNGLQUOTES>\'           {BEGIN(INITIAL);}
+<SNGLQUOTES>[^\']+      {yylval.s = strdup(yytext); return WORD;
+                                      BEGIN(INITIAL);}
+
+
 ([^\t \n\"\?\\\'\&><\|]|\\&|\\\"|\\>|\\<|\\\'|\\\|)+ {yylval.s = strdup(yytext); return WORD;}
-(\"(\\.|[^\\"])*\")|(\'(\\.|[^\\'])*\')  {char unquoted[yyleng+1];
-                                          strncpy(unquoted, yytext, yyleng+1); 
-                                          unquote(unquoted);
-                                          yylval.s = strdup(unquoted);
-                                          return WORD;}
 (&)                                      {return *yytext;}
 (2>)					                           {return RE_STDERR;}
 (&1)                                     {return STDOUT;}
@@ -22,45 +32,11 @@ char * unquote(char *string);
 [ \t\r]+                		             {;}
 <<EOF>>                           {return END_OF_FILE;}
 
-.                       		             {yyerror("Invalid character!");}
+.                       		             {yyerror("Invalid character!"); return ERRTOK;}
 
 %%
 
 int yywrap(void)
 {
   return 1;
-}
-
-char * unquote(char *string) {
-  /* We can strip quotes in the lexer,
-   * making parsing easier because then
-   * it can be parsed as a normal word.
-   */
-  char *strp = string;
-  int stringlen = strlen(strp);
-  int r = 0; // for reading the string
-  int w = 0; // for writing back to the string
-  if (strp[0] == '"') { // if the string is double quoted
-    for (r=0; r<stringlen; r++) { // loop over the string
-      if (strp[r] != '"' && strp[r] != '\\') { // regular char
-        strp[w++] = strp[r]; // keep the char
-      } else if (strp[r+1] == '"' && strp[r] == '\\') { // escaped '"'
-	strp[w++] = '"';
-      } else if (strp[r+1] != '"' && strp[r] == '\\') { // regular '\'
-	strp[w++] = '\\';
-      }
-    }
-  } else if (strp[0] == '\'') { // if the string is single quoted
-  for (r=0; r<stringlen; r++) { // same as for double quote
-      if (strp[r] != '\'' && strp[r] != '\\') {
-        strp[w++] = strp[r];
-      } else if (strp[r+1] == '\'' && strp[r] == '\\') {
-        strp[w++] = '\'';
-      } else if (strp[r+1] != '\'' && strp[r] == '\\') {
-        strp[w++] = '\\';
-      }   
-    }
-  }   
-  strp[w] = '\0';
-  return (string);
 }

--- a/shparser.y
+++ b/shparser.y
@@ -21,7 +21,7 @@ int yylex(void);
 
 %token <num> NUMBER;
 %token <s> WORD;
-%token ERRTOK STDOUT RE_STDERR;
+%token ERRTOK STDOUT RE_STDERR END_OF_FILE;
 %token '\n' '>' '<' '&'
 %left '|'
 %type <np> command commands redir params param commandline
@@ -40,6 +40,8 @@ line : line commands '\n'               {fprintf(stdout, "line commands\n");
                                          RootNode = $2; runBG = 1; YYACCEPT;}
      | /*EMPTY*/      
      | line '\n'
+     | END_OF_FILE               {fprintf(stdout, "Reached EOF, exit\n"); 
+                                             doneParsing = 1; YYACCEPT;}
      ;
 
 command : WORD                          {fprintf(stdout, "WORD (%s)\n", $1); $$ = new_command($1, NULL);}

--- a/shparser.y
+++ b/shparser.y
@@ -30,15 +30,11 @@ int yylex(void);
 
 start : line                            {fprintf(stdout, "start\n");}
 
-line : line command '\n'                {fprintf(stdout, "line command\n"); 
-                                         RootNode = $2; YYACCEPT;}
-     | line commands '\n'               {fprintf(stdout, "line commands\n"); 
+line : line commands '\n'               {fprintf(stdout, "line commands\n"); 
                                          RootNode = $2; YYACCEPT;}
      | line redir '\n'                  {fprintf(stdout, "line redir\n");
                                          RootNode = $2; YYACCEPT;}
-     | line command '&' '\n'            {fprintf(stdout, "line command\n"); 
-                                         RootNode = $2; runBG = 1; YYACCEPT;}
-     | line commands '&' '\n'           {fprintf(stdout, "line commands\n"); 
+     | line commands '&' '\n'            {fprintf(stdout, "line command\n"); 
                                          RootNode = $2; runBG = 1; YYACCEPT;}
      | line redir '&' '\n'              {fprintf(stdout, "line redir\n"); 
                                          RootNode = $2; runBG = 1; YYACCEPT;}
@@ -89,8 +85,6 @@ redir : commandline '<' WORD                                     {fprintf(stdout
       ;
 
 commandline : commands                                          {fprintf(stdout, "commandline\n"); 
-                                                                $$ = $1;}
-            | command                                           {fprintf(stdout, "commandline\n"); 
                                                                 $$ = $1;}
             ;
 

--- a/shparser.y
+++ b/shparser.y
@@ -21,31 +21,81 @@ int yylex(void);
 
 %token <num> NUMBER;
 %token <s> WORD;
-%token ERRTOK;
-%token '\n' '>' '<'
+%token ERRTOK STDOUT RE_STDERR;
+%token '\n' '>' '<' '&'
 %left '|'
-%type <np> command commands params param
+%type <np> command commands redir params param commandline
 
 %%
 
-start : line        			{fprintf(stdout, "start\n");}
+start : line                            {fprintf(stdout, "start\n");}
 
 line : line command '\n'                {fprintf(stdout, "line command\n"); 
-               				 RootNode = $2; YYACCEPT;}
+                                         RootNode = $2; YYACCEPT;}
      | line commands '\n'               {fprintf(stdout, "line commands\n"); 
-           				 RootNode = $2; YYACCEPT;}
+                                         RootNode = $2; YYACCEPT;}
+     | line redir '\n'                  {fprintf(stdout, "line redir\n");
+                                         RootNode = $2; YYACCEPT;}
+     | line command '&' '\n'            {fprintf(stdout, "line command\n"); 
+                                         RootNode = $2; runBG = 1; YYACCEPT;}
+     | line commands '&' '\n'           {fprintf(stdout, "line commands\n"); 
+                                         RootNode = $2; runBG = 1; YYACCEPT;}
+     | line redir '&' '\n'              {fprintf(stdout, "line redir\n"); 
+                                         RootNode = $2; runBG = 1; YYACCEPT;}
      | /*EMPTY*/      
      | line '\n'
      ;
 
 command : WORD                          {fprintf(stdout, "WORD (%s)\n", $1); $$ = new_command($1, NULL);}
-	| ERRTOK			{fprintf(stdout, "cmd ERRTOK!\n"); YYABORT;}
+        | ERRTOK                        {fprintf(stdout, "cmd ERRTOK!\n"); YYABORT;}
         | WORD params                   {fprintf(stdout, "WORD (%s) params\n", $1);$$ = new_command($1, $2);}
-	| ERRTOK params			{fprintf(stdout, "ERRTOK! params\n"); YYABORT;}
+        | ERRTOK params                 {fprintf(stdout, "ERRTOK! params\n"); YYABORT;}
         ;
 
+redir : commandline '<' WORD                                     {fprintf(stdout, "< WORD\n"); 
+                                                                $$ = new_redir($1, $3, NULL, 0, NULL, 0);}
+      | commandline '<' WORD '>' WORD                            {fprintf(stdout, "< WORD > WORD\n");
+                                                                $$ = new_redir($1, $3, $5, 0, NULL, 0);}
+      | commandline '<' WORD '>' '>' WORD                        {fprintf(stdout, "< WORD >> WORD\n");
+                                                                $$ = new_redir($1, $3, $6, 1, NULL, 0);}
+      | commandline '<' WORD '>' WORD RE_STDERR WORD             {fprintf(stdout, "< WORD > WORD RE_STDERR WORD\n");
+                                                                $$ = new_redir($1, $3, $5, 0, $7, 0);}
+      | commandline '<' WORD '>' WORD RE_STDERR STDOUT           {fprintf(stdout, "< WORD > WORD RE_STDERR STOUT\n");
+                                                                $$ = new_redir($1, $3, $5, 0, NULL, 1);}
+      | commandline '<' WORD '>' '>' WORD RE_STDERR WORD         {fprintf(stdout, "< %s >> %s 2> %s\n", $3, $6, $8);
+                                                                $$ = new_redir($1, $3, $6, 1, $8, 0);}
+      | commandline '<' WORD '>' '>' WORD RE_STDERR STDOUT       {fprintf(stdout, "< WORD >> WORD RE_STDERR STOUT\n");
+                                                                $$ = new_redir($1, $3, $6, 1, NULL, 1);}
+      | commandline '>' WORD                                     {fprintf(stdout, "> WORD\n");
+                                                                $$ = new_redir($1, NULL, $3, 0, NULL, 0);}
+      | commandline '>' '>' WORD                                 {fprintf(stdout, ">> WORD\n");
+                                                                $$ = new_redir($1, NULL, $4, 1, NULL, 0);}
+      | commandline '>' WORD RE_STDERR WORD                      {fprintf(stdout, "> WORD RE_STDERR WORD\n");
+                                                                $$ = new_redir($1, NULL, $3, 0, $5, 0);}
+      | commandline '>' '>' WORD RE_STDERR WORD                  {fprintf(stdout, ">> WORD RE_STDERR WORD\n");
+                                                                $$ = new_redir($1, NULL, $4, 1, $6, 0);}
+      | commandline '>' WORD RE_STDERR STDOUT                    {fprintf(stdout, "> WORD RE_STDERR STDOUT\n");
+                                                                $$ = new_redir($1, NULL, $3, 0, NULL, 1);}
+      | commandline '>' '>' WORD RE_STDERR STDOUT                {fprintf(stdout, ">> WORD RE_STDERR STDOUT\n");
+                                                                $$ = new_redir($1, NULL, $4, 1, NULL, 1);}
+      | commandline '<' WORD RE_STDERR WORD                      {fprintf(stdout, "< WORD RE_STDERR WORD\n");
+                                                                $$ = new_redir($1, $3, NULL, 0, $5, 0);}
+      | commandline '<' WORD RE_STDERR STDOUT                    {fprintf(stdout, "< WORD RE_STDERR STDOUT\n");
+                                                                $$ = new_redir($1, $3, NULL, 0, NULL, 1);}
+      | commandline RE_STDERR WORD                               {fprintf(stdout, "RE_STDERR WORD\n");
+                                                                $$ = new_redir($1, NULL, NULL, 0, $3, 0);}
+      | commandline RE_STDERR STDOUT                             {fprintf(stdout, "RE_STDERR\n");
+                                                                $$ = new_redir($1, NULL, NULL, 0, NULL, 0);}
+      ;
+
+commandline : commands                                          {fprintf(stdout, "commandline\n"); 
+                                                                $$ = $1;}
+            | command                                           {fprintf(stdout, "commandline\n"); 
+                                                                $$ = $1;}
+            ;
+
 param : WORD                            {fprintf(stdout, "WORD (%s)\n", $1); $$ = new_param($1);}
-      | ERRTOK				{fprintf(stdout, "ERRTOK!\n"); YYABORT;}
+      | ERRTOK                          {fprintf(stdout, "ERRTOK!\n"); YYABORT;}
       ;
 
 commands : command '|' commands         {fprintf(stdout, "command | commands\n"); $$ = new_pipe($1, $3);}


### PR DESCRIPTION
Redirection should work properly when it follows the pattern:
cmd [arg]* [|cmd [arg]*]* [< fn1]* [ >[>]* fn2 ]* [ 2>fn3 || 2>&1 ]*
Made a global variable to check if the command should be processed in the background.
Used start conditions to handle quotes in lexer.
Now exits on EOF.